### PR TITLE
refactor(api): update Google Generative AI initialization

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,7 +1,13 @@
 import type { TimelineEntry } from "@/entities/timeline/types";
 import { getVideoDetails } from "@/entities/video/actions/video-actions";
-import { google } from "@ai-sdk/google";
+import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import { streamText } from "ai";
+
+const { GOOGLE_GENERATIVE_AI_API_KEY } = process.env;
+
+const google = createGoogleGenerativeAI({
+  apiKey: GOOGLE_GENERATIVE_AI_API_KEY,
+});
 
 const model = google("gemini-2.0-flash-001");
 

--- a/entities/timeline/actions/timeline-actions.ts
+++ b/entities/timeline/actions/timeline-actions.ts
@@ -1,5 +1,5 @@
 "use server";
-import { google } from "@ai-sdk/google";
+import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import { streamObject } from "ai";
 import { z } from "zod";
 import {
@@ -23,6 +23,12 @@ const timelineSchema = z.object({
       })
     )
     .describe("Entradas de la línea de tiempo para los momentos clave"),
+});
+
+const { GOOGLE_GENERATIVE_AI_API_KEY } = process.env;
+
+const google = createGoogleGenerativeAI({
+  apiKey: GOOGLE_GENERATIVE_AI_API_KEY,
 });
 
 const model = google("gemini-2.0-flash-001");


### PR DESCRIPTION
Update the initialization of Google Generative AI to use `createGoogleGenerativeAI` and include the API key from environment variables. This change ensures consistency and proper configuration across the codebase.